### PR TITLE
Tweak section/paragraph/headline spacing

### DIFF
--- a/src/Home.elm
+++ b/src/Home.elm
@@ -30,17 +30,25 @@ missionStatement =
 
 We want to foster a welcoming and inclusive community of people who like to learn Elm, work with Elm or help others learn Elm.
 
-- **Collaboration** We would like for the meetups to become a nice way to work on your own Elm-related projects in the company of other likeminded people.
+### Collaboration
+
+We would like for the meetups to become a nice way to work on your own Elm-related projects in the company of other likeminded people.
 A space of collaboration, communication, and community. We will still have talks, but those shouldn't be the main focus of the events.
-- **Anyone is a speaker** You don't need to present if you don't feel like it. But if you have a hobby project you've been working on,
+
+### Anyone is a speaker
+
+You don't need to present if you don't feel like it. But if you have a hobby project you've been working on,
 or a solution to a specific problem, just bring it up with the organizers and we'll figure out a nice format for you!
-- **Not just traditional talks** It takes a considerable amount of time to prepare and rehearse a traditional talk. We want to keep
+
+### Not just traditional talks
+
+It takes a considerable amount of time to prepare and rehearse a traditional talk. We want to keep
 the barrier of entry as low as possible, and as such, welcome presentations that could be for example:
-    - Show an article/blog post/idea you've come across (e.g. 5 minutes)
-    - Show your code: quickly explain what you've built by showing the end result and a little bit of code
-    - Inverted talk: pull up a chair and have the "panel" in front of you answer tricky questions
-    - Tell what you are working on — in your own words, no slides or preparation necessary
-    - Slide-deck talk — these are welcome too!
+- Show an article/blog post/idea you've come across (e.g. 5 minutes)
+- Show your code: quickly explain what you've built by showing the end result and a little bit of code
+- Inverted talk: pull up a chair and have the "panel" in front of you answer tricky questions
+- Tell what you are working on — in your own words, no slides or preparation necessary
+- Slide-deck talk — these are welcome too!
 
 
 In a nutshell collaboration, coding, and feeling part of a group is the main focus of these events.

--- a/style.css
+++ b/style.css
@@ -50,8 +50,8 @@ img {
   --small: 0.75em;
   background-color: var(--orange1);
   color: var(--text-color);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   line-height: 1.5;
 }
 
@@ -78,17 +78,6 @@ img {
     --h5: 1.333em;
     --text: 1.333em;
     --small: 0.75em;
-  }
-}
-
-@media (max-width:480px) {
-  :root {
-    /* Minor third */
-    --h1: 2.488em;
-    --h2: 2.074em;
-    --h3: 1.728em;
-    --h4: 1.44em;
-    --h5: 1.2em;
   }
 }
 
@@ -151,10 +140,6 @@ h5 {
   font-size: var(--h5);
 }
 
-p {
-  font-size: var(--text);
-}
-
 small,
 .text-small {
   font-size: var(--small);
@@ -164,12 +149,31 @@ body {
   max-width: 48em;
   padding-top: 2rem;
   padding-bottom: 2rem;
-  padding-left: 8rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  font-size: var(--text);
+}
+
+@media screen and (min-width: 48rem) {
+  body {
+    padding-left: 8rem;
+  }
 }
 
 /* Section spacing */
 section + section {
   margin-top: 4rem;
+}
+
+/* Paragraph spacing */
+/* Let the headings lead */
+p {
+  margin: 0;
+}
+
+/* Set inter-paragraph spacing */
+p + p {
+  margin-top: 1em;
 }
 
 /* Hyphenation */


### PR DESCRIPTION
This PR tweaks the spacing for sections, paragraphs, and headlines.

The rules are now like this:
- Headlines set a higher top than bottom margin. It is based on ems, so it scales automatically.
- Headline spacing leads the spacing when followed by a paragraph
- Paragraphs have a space between them of 1em between them

Also tweaked the left padding for body.