### PR TITLE
Add ids to level 2 and 3 headings

### DIFF
--- a/src/Home.elm
+++ b/src/Home.elm
@@ -196,8 +196,8 @@ sectionFromMarkdown (Markdown mdString) =
         )
 
 
-{-| Add ids to headings of level 2 and 3, to allow linking with '#id' |
-    In the future, we could decide to append an anchor tag here
+{-| Add ids to headings of level 2 and 3, to allow linking with '#id'
+In the future, we could decide to append an anchor tag here
 -}
 withHeadingAnchors : Block b i -> List (Html msg)
 withHeadingAnchors block =


### PR DESCRIPTION
I think that linking to the main headings (2 and 3) can be useful. I liked the markdown parser, and thought to add them automatically in the blocks. 

In the future, we can decide to show these links explicitly. It might make the site look too "Readme"-ish. Also, that pattern needs a number of decisions (I wrote a bit about it before https://fotis.xyz/posts/linking-to-headings/), so I'm deferring that :) Still, being able to link directly is handy, hence this PR.